### PR TITLE
Fix image name in app-env

### DIFF
--- a/script/app-env
+++ b/script/app-env
@@ -3,11 +3,13 @@
 
 set -e
 
-appdir=$(cd $(dirname "$0")/.. && pwd)
 [ -f /etc/inside-container ] && exec "$@"
 
+appdir=$(cd $(dirname "$0")/.. && pwd)
+imagename="${PWD##*/}_web"
+
 cmd="$@"; [ "$#" -eq 0 ] && cmd=bash
-image=${DOCKER_IMAGE:=flask-template}
+image=${DOCKER_IMAGE:=$imagename}
 
 if [ ! -f script/.env ]; then
     echo "Environment variables file (script/.env) not found!"


### PR DESCRIPTION
When building a container with `docker-compose` by default it uses the containing directory name plus and underscore and the name of the `services` defined in `docker-compose.yml`. In this example, the service is named `web` so this will be appended to the top-level directory name creating `flask-template_web` for the image name. This change updates the image name in `app-env` to follow the default pattern.